### PR TITLE
Added flake file and adjusted shebang

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,21 @@
+{
+    description = "A very basic flake";
+
+    inputs = {
+        nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+    };
+
+    outputs = { self, nixpkgs }:
+    let
+        pkgs = nixpkgs.legacyPackages."x86_64-linux";
+    in
+    {
+        devShells."x86_64-linux".default = pkgs.mkShell {
+            packages = with pkgs; [ 
+                    python313
+                    python313Packages.gitpython
+                    python313Packages.distutils
+                ];
+        };
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-    description = "A very basic flake";
+    description = "Default flake for running loupe";
 
     inputs = {
         nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";

--- a/loupe
+++ b/loupe
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # SPDX-License-Identifier: BSD-3-Clause
 #


### PR DESCRIPTION
Added flake file, users on NixOS can download all dependencies using `nix develop`

Adjusted `loupe` shebang to use `/usr/bin/env python3` to be more universal